### PR TITLE
Add a way to automatically trigger dialogue on collision

### DIFF
--- a/assets/dialogue/level1.dialogue
+++ b/assets/dialogue/level1.dialogue
@@ -37,7 +37,7 @@
         ),
         (
             name: "invisibleStop",
-            body: Text("Try as you might, this route is impassable... [space]"),
+            body: Text("Try as you might, this route is impassable..."),
         ),
         (
             body: End,
@@ -45,6 +45,17 @@
         (
             name: "gemTrap",
             body: Text("Wow."),
+        ),
+        (
+            body: End,
+        ),
+        (
+            name: "collectedBigGem",
+            body: Text("The gem barely fits in your bag of holding, you won't be able to keep it for long..."),
+        ),
+        (
+            name: "exitWorld",
+            body: Text("In your heart, there is an inexorable tug towards the aether..."),
         ),
         (
             body: End,

--- a/assets/maps/sandyrocks.tmx
+++ b/assets/maps/sandyrocks.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="22" height="22" tilewidth="64" tileheight="64" infinite="0" nextlayerid="10" nextobjectid="109">
+<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="22" height="22" tilewidth="64" tileheight="64" infinite="0" nextlayerid="10" nextobjectid="112">
  <tileset firstgid="1" name="crystal_set" tilewidth="100" tileheight="100" tilecount="5" columns="5">
   <image source="melle/crystal_set.png" width="500" height="100"/>
  </tileset>
@@ -14,7 +14,7 @@
  </tileset>
  <layer id="1" name="background" width="22" height="22" tintcolor="#ffd8bd">
   <data encoding="base64" compression="zlib">
-   eJyVlMlv01AQh9+xbhyzBFJsKAlLnA2x3JBoDyAQygHRhUVColCJA1AqJPj/JX4jvpEnVkrK4ZPt53nz5v1mmaWUBqIUHbHJ95S1StRiyLdxBZuuuCfuiwfiUbApgl+zz3nv8W9DZKxtwIjnWDwX++JA7LKnCv7KM6i5Q8H7mHvZ3onYEx/FkViEe14QF8Xlf/guuXMW4vfzvopv8Is146roi2tr/Doj9nXX2N0Sd8Tdc/o9L9PWt+ti+b2EPhN0LdAgC3Y7Ya/l2msp504d/rkuN8SWOBYzfLkGFXafxVti2MFvDz8WyxBby8l1fPbxuwh2ZYjXzz8UP8QpcXY5e0qssxXxboub3Mnu/QFdMs5/Iz4Rs+thNVsHXQzrnSN8HrLP6+SVeC9ec47l+7Y4wdbvVaamN+etWPvEYfrtpqZufqa/dRPz9g7b47S6HkZBW8/ZPrrlaXk+uL4vxBfxHbt2fdVgvXMQ/LZ7JQ/ve6nppzG6Fi17nyFRiy1ylpFfz63n8CHnL1q+4syrUlN3rkWsBfM94Jljsw2r+t/no2nyVDwTL9Hr5Iw9nkOrhXb/e2/5fLRYH5PXRdj7PzPDatTm+jys1fi1/D5Zs3+IbrH3S3J+igYVObD5Yv3gdTUll7Z3Qgwz1ub47gWfPgvyEK/nyXr8N2eNeA7wZXGNOc9zUqVmzvv5RWpqzXMQtfRzO9j30nJfjNOyNpvY5amZT38AZmlAQg==
+   eJyVlMlv01AQh9+xbpywBFJsKAlL7CyI5YZEewCBUA6ILiwnCpU4AKVCgv9f4jfqN/LESkk5fLL9PG/evN8ss5TSUBSiIzb5nrJWikqM+DauYdMVD8RD8Ug8CTa94Nfsc977/NsQGWsbMOZZi5diXxyIXfaUwV9xDhV36PFecy/bOxF74pM4Eotwz0visrj6D98Fd85C/H7eN/EdfrNmXBcDcWONX2fMvu4auzvinrh/Qb8XZdr6dl0sv1fQZ4KuPTTIgt1O2Gu59lrKuVOHf67LLbEljsUMX65Bid0X8Z4YdvDbx4/FMsLWcnITnwP8LoJdEeL18w/FT3FKnF3OnhLrbEW82+I2d7J7v0CXjPPfic/E7HpYzVZBF8N65wifh+zzOnkjPoq3nGP5vitOsPV7FanpzXkr1gFxmH67qambX+msbmLePmB7nFbXwzho6znbR7c8Lc8H1/eV+Cp+YNeurwqsdw6C33av5OF9LzX9VKNrr2XvMyRqsUXOMvLrufUcPub8RctXnHllaurOtYi1YL6HPHNstmFV//t8NE2ep7M6eo1eJ+fs8RxaLbT733vL56PF+pS8LsLe/5kZVqM21+dhrcKv5ffZmv0jdIu9X5DzUzQoyYHNF+sHr6spubS9E2KYsTbHdz/49FmQh3g9T9bjfzhrzHOIL4ur5jzPSZmaOe/n91JTa56DqKWf28G+n5b7ok7L2mxil6dmPv0F/zpAKg==
   </data>
  </layer>
  <objectgroup id="2" name="items">
@@ -55,7 +55,8 @@
   <object id="12" x="-15.1515" y="1411.36" width="1421.82" height="96"/>
   <object id="82" x="437.25" y="915.75" width="28" height="53">
    <properties>
-    <property name="dialogue" value="invisibleStop"/>
+    <property name="autodisplay" type="bool" value="true"/>
+    <property name="notice" value="invisibleStop"/>
    </properties>
   </object>
   <object id="39" name="spawn" x="797.666" y="1246.17" width="50" height="44.5"/>
@@ -162,6 +163,12 @@
   <object id="106" x="-1230.79" y="727.561" width="186" height="142">
    <properties>
     <property name="dialogue" value="astralChill"/>
+   </properties>
+  </object>
+  <object id="111" name="trigger" x="-106.561" y="57.7272" width="79.7879" height="108.788">
+   <properties>
+    <property name="autodisplay" type="bool" value="true"/>
+    <property name="notice" value="exitWorld"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/core/game.rs
+++ b/src/core/game.rs
@@ -28,14 +28,21 @@ impl Game {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
 pub struct DialogueSpec {
     pub node_name: String,
     pub ui_type: DialogueUiType,
+    pub auto_display: bool,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum DialogueUiType {
     MovementDisabled,
     Notice,
+}
+
+impl Default for DialogueUiType {
+    fn default() -> Self {
+        DialogueUiType::MovementDisabled
+    }
 }

--- a/src/items.rs
+++ b/src/items.rs
@@ -4,16 +4,7 @@ use bevy::{asset::FileAssetIo, prelude::*};
 use bevy::utils::HashSet;
 use bevy_tiled_prototype::Object;
 
-use crate::{
-    core::{
-        collider::{Collider, ColliderBehavior},
-        dialogue::{Dialogue, DialogueEvent},
-        game::Game,
-        state::{AppState, TransientState},
-    },
-    loading::LoadProgress,
-    scene2d::load_next_map,
-};
+use crate::{core::{collider::{Collider, ColliderBehavior}, dialogue::{Dialogue, DialogueEvent}, game::{DialogueSpec, Game}, state::{AppState, TransientState}}, loading::LoadProgress, scene2d::load_next_map};
 
 #[derive(Debug, Default)]
 pub struct ItemsPlugin;
@@ -183,7 +174,14 @@ pub fn inventory_item_reveal_system(
             for (object, mut visible, mut collider) in object_query.iter_mut() {
                 if object.name == "biggem" {
                     visible.is_visible = true;
+                    collider.behaviors.clear();
                     collider.insert_behavior(ColliderBehavior::Collect);
+                    collider.insert_behavior(ColliderBehavior::Dialogue(
+                        DialogueSpec {
+                            node_name: "collectedBigGem".to_string(),
+                            ui_type: crate::core::game::DialogueUiType::Notice,
+                            auto_display: true,
+                    }));
                 }
             }
         }

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -108,26 +108,29 @@ pub fn setup_map_objects_system(
 
             let mut behaviors: HashSet<ColliderBehavior> = Default::default();
 
+            let mut has_dialogue = false;
+            let mut dialogue_spec = DialogueSpec::default();
             for (k,v) in object.props.iter() {
                 if k == "dialogue" {
                     if let PropertyValue::StringValue(s) = v {
-                        behaviors.insert(ColliderBehavior::Dialogue(
-                            DialogueSpec {
-                                node_name: s.clone(),
-                                ui_type: DialogueUiType::MovementDisabled,
-                            }));
-                        break;
+                        has_dialogue = true;
+                        dialogue_spec.node_name = s.clone();
+                        dialogue_spec.ui_type = DialogueUiType::MovementDisabled;
                     }
                 } else if k == "notice" {
                     if let PropertyValue::StringValue(s) = v {
-                        behaviors.insert(ColliderBehavior::Dialogue(
-                            DialogueSpec {
-                                node_name: s.clone(),
-                                ui_type: DialogueUiType::Notice,
-                            }));
-                        break;
+                        has_dialogue = true;
+                        dialogue_spec.node_name = s.clone();
+                        dialogue_spec.ui_type = DialogueUiType::Notice;
+                    }
+                } else if k == "autodisplay" {
+                    if let PropertyValue::BoolValue(b) = v {
+                        dialogue_spec.auto_display = *b;
                     }
                 }
+            }
+            if has_dialogue {
+                behaviors.insert(ColliderBehavior::Dialogue(dialogue_spec));
             }
 
             // we should have actual types based on object name

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -109,6 +109,7 @@ pub fn setup_map_objects_system(
             let mut behaviors: HashSet<ColliderBehavior> = Default::default();
 
             let mut has_dialogue = false;
+            let mut auto_display_override = None;
             let mut dialogue_spec = DialogueSpec::default();
             for (k,v) in object.props.iter() {
                 if k == "dialogue" {
@@ -116,20 +117,25 @@ pub fn setup_map_objects_system(
                         has_dialogue = true;
                         dialogue_spec.node_name = s.clone();
                         dialogue_spec.ui_type = DialogueUiType::MovementDisabled;
+                        dialogue_spec.auto_display = false;
                     }
                 } else if k == "notice" {
                     if let PropertyValue::StringValue(s) = v {
                         has_dialogue = true;
                         dialogue_spec.node_name = s.clone();
                         dialogue_spec.ui_type = DialogueUiType::Notice;
+                        dialogue_spec.auto_display = true;
                     }
                 } else if k == "autodisplay" {
                     if let PropertyValue::BoolValue(b) = v {
-                        dialogue_spec.auto_display = *b;
+                        auto_display_override = Some(*b);
                     }
                 }
             }
             if has_dialogue {
+                if let Some(b) = auto_display_override {
+                    dialogue_spec.auto_display = b;
+                }
                 behaviors.insert(ColliderBehavior::Dialogue(dialogue_spec));
             }
 

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -136,7 +136,7 @@ pub fn setup_map_objects_system(
             // we should have actual types based on object name
             // and add components based on that
             match object.name.as_ref() {
-                "spawn" => {}
+                "spawn" | "trigger" => {}
                 "biggem" | "gem" => {
                     if object.visible {
                         behaviors.insert(ColliderBehavior::Collect);

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -134,7 +134,14 @@ pub fn setup_map_objects_system(
             }
             if has_dialogue {
                 if let Some(b) = auto_display_override {
-                    dialogue_spec.auto_display = b;
+                    match dialogue_spec.ui_type {
+                        DialogueUiType::MovementDisabled => {
+                            eprintln!("Warning: Auto-display of dialogue isn't currently supported")
+                        }
+                        DialogueUiType::Notice => {
+                            dialogue_spec.auto_display = b;
+                        }
+                    }
                 }
                 behaviors.insert(ColliderBehavior::Dialogue(dialogue_spec));
             }

--- a/src/motion.rs
+++ b/src/motion.rs
@@ -197,7 +197,11 @@ fn dialogue_behavior(behaviors: &HashSet<ColliderBehavior>) -> Option<DialogueSp
             ColliderBehavior::Collect => {}
             ColliderBehavior::Load { path: _ } => {}
             ColliderBehavior::Dialogue(spec) => {
-                return Some(spec.clone());
+                // If it should be auto-displayed, another system already
+                // displays it.
+                if !spec.auto_display {
+                    return Some(spec.clone());
+                }
             }
         }
     }


### PR DESCRIPTION
With this, you can add a property to a map object called `autodisplay` with a boolean value `true` to auto-trigger either dialogue or a notice.