### PR TITLE
Collision shapes support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,9 +639,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_tiled_prototype"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dacba8f267900c1ac5aa35c667d1a5ff7cd7104f5bac1070bde9d48c723303c"
+version = "0.2.5"
+source = "git+https://github.com/chipflask/bevy_tiled/?branch=embedded_objects#d0f696c2c61322bcef96d5e0078fbfb0c3f6736e"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1860,15 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -3205,7 +3195,6 @@ dependencies = [
  "base64 0.10.1",
  "libflate",
  "xml-rs",
- "zstd",
 ]
 
 [[package]]
@@ -3326,7 +3315,7 @@ checksum = "85e00391c1f3d171490a3f8bd79999b0002ae38d3da0d6a3a306c754b053d71b"
 
 [[package]]
 name = "twodina"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bevy",
@@ -3651,34 +3640,3 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-
-[[package]]
-name = "zstd"
-version = "0.5.4+zstd.1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "2.0.6+zstd.1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.4.18+zstd.1.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
-dependencies = [
- "cc",
- "glob",
- "itertools",
- "libc",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "twodina"
 description = "A 2d game engine on top of Bevy."
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Jonathan Tran <jonnytran@gmail.com>", "Daniel Taub <dmtaub@gmail.com>"]
 edition = "2018"
 
@@ -10,15 +10,16 @@ edition = "2018"
 [dependencies]
 anyhow = "^1.0.36"
 bevy = { version = "0.5.0", features=["vorbis"] }
-bevy_tiled_prototype = "0.2.3"
+bevy_tiled_prototype = "0.2.5"
 parry2d = "^0.3.0"
 ron = "0.6.4"
 serde = { version = "^1.0.123", features = ["derive"] }
 toml = "0.5"
 
-#[patch.crates-io]
+[patch.crates-io]
+bevy_tiled_prototype = { git = "https://github.com/chipflask/bevy_tiled/", branch = "embedded_objects" }
+#bevy_tiled_prototype = { path = "../bevy_tiled" }
 # bevy = { git = "https://github.com/bevyengine/bevy/", branch = "main", features = ["vorbis"] }
-# bevy_tiled_prototype = { path = "../bevy_tiled" }
 
 [profile.dev]
 # Speed up dev build on macOS.

--- a/assets/app.toml
+++ b/assets/app.toml
@@ -3,7 +3,10 @@ title = "Celebration 2021: Twodina"
 
 # Path is relative to /assets and shouldn't start with a /.
 start_map = "maps/sandyrocks.tmx"
+map_scale = 2.0
 start_dialogue = "dialogue/level1.dialogue"
+#start_map = "../../bevy_tiled/assets/ortho-debug.tmx"
+#map_scale = 4.0
 
 # Characters to use - for multiple, {} will be replaced:
 char_template = "sprites/azuna{}.png"

--- a/assets/app.toml
+++ b/assets/app.toml
@@ -17,3 +17,5 @@ char_width = 32.0
 # char_height = 26.0
 # char_width = 36.0
 
+walk_speed = 175.0
+run_speed = 400.0

--- a/assets/maps/sandyrocks.tmx
+++ b/assets/maps/sandyrocks.tmx
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="22" height="22" tilewidth="64" tileheight="64" infinite="0" nextlayerid="10" nextobjectid="113">
+<map version="1.5" tiledversion="1.5.0" orientation="orthogonal" renderorder="right-down" width="22" height="22" tilewidth="64" tileheight="64" infinite="0" nextlayerid="10" nextobjectid="115">
  <tileset firstgid="1" name="crystal_set" tilewidth="100" tileheight="100" tilecount="5" columns="5">
   <image source="melle/crystal_set.png" width="500" height="100"/>
  </tileset>
  <tileset firstgid="6" name="trees" tilewidth="54" tileheight="72" tilecount="2" columns="2">
   <image source="trees.png" width="108" height="72"/>
+  <tile id="0">
+   <objectgroup draworder="index" id="2">
+    <object id="1" x="15.125" y="52.5625" width="24.75" height="19.25"/>
+   </objectgroup>
+  </tile>
+  <tile id="1">
+   <objectgroup draworder="index" id="2">
+    <object id="1" x="16.125" y="52.625" width="24.875" height="19.5"/>
+   </objectgroup>
+  </tile>
  </tileset>
  <tileset firstgid="8" name="grassy_stones_64" tilewidth="64" tileheight="64" tilecount="36" columns="6">
   <image source="melle/grassy_stones_64.png" width="384" height="384"/>
@@ -43,14 +53,15 @@
   <object id="20" gid="6" x="959.474" y="623.696" width="81.7993" height="109.066"/>
   <object id="21" gid="6" x="916.095" y="1008.23" width="78.7993" height="105.066"/>
   <object id="22" name="load:ritualspace" gid="7" x="-225.848" y="-58.2985" width="160.549" height="190.066"/>
-  <object id="23" gid="7" x="285.619" y="935.169" width="83.5493" height="111.399"/>
+  <object id="23" gid="7" x="295.619" y="978.836" width="83.5493" height="111.399"/>
   <object id="24" gid="7" x="962.609" y="487.494" width="75.0493" height="100.066"/>
-  <object id="40" gid="7" x="390.225" y="911.55" width="83.5493" height="111.399"/>
-  <object id="42" gid="7" x="439.475" y="1083.05" width="83.5493" height="111.399"/>
-  <object id="43" gid="7" x="287.725" y="1057.3" width="83.5493" height="111.399"/>
+  <object id="40" gid="7" x="372.892" y="925.217" width="83.5493" height="111.399"/>
+  <object id="42" gid="7" x="407.475" y="1040.38" width="83.5493" height="111.399"/>
+  <object id="43" gid="7" x="305.725" y="1043.63" width="83.5493" height="111.399"/>
   <object id="44" gid="7" x="1005.14" y="851.3" width="75.0493" height="100.066"/>
   <object id="78" gid="7" x="180.225" y="1113.8" width="83.5493" height="111.399"/>
   <object id="84" gid="7" x="260.225" y="1305.3" width="83.5493" height="111.399"/>
+  <object id="113" gid="7" x="325.892" y="937.967" width="83.5493" height="111.399"/>
  </objectgroup>
  <objectgroup id="4" name="walls">
   <object id="9" x="-129.242" y="174.879" width="120" height="1245.27"/>

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,16 +1,7 @@
 use bevy::prelude::*;
 
 use bevy_tiled_prototype::Map;
-use crate::{
-    debug::Debuggable,
-    core::{
-        character::{RUN_SPEED, WALK_SPEED, Character, CharacterState, Direction},
-        dialogue::{Dialogue, DialogueEvent},
-        game::{DialogueSpec, Game},
-        input::{Action, Flag, InputActionSet},
-        state::TransientState,
-    },
-};
+use crate::{core::{character::{Character, CharacterState, Direction}, config::Config, dialogue::{Dialogue, DialogueEvent}, game::{DialogueSpec, Game}, input::{Action, Flag, InputActionSet}, state::TransientState}, debug::Debuggable};
 
 use crate::motion::VELOCITY_EPSILON;
 use crate::players::Player;
@@ -30,6 +21,7 @@ pub fn handle_movement_input_system(
     mut query: Query<(&mut Character, &Player)>,
     dialogue_query: Query<&Dialogue>,
     mut debuggable: Query<(&mut Visible, Option<&Handle<Map>>), With<Debuggable>>,
+    config: Res<Config>,
 ) {
     // check for debug status flag differing from transient_state to determine when to hide/show debug stuff
     if input_actions.has_flag(Flag::Debug) != transient_state.debug_mode {
@@ -85,13 +77,13 @@ pub fn handle_movement_input_system(
         }
 
         if input_actions.is_active(Action::Walk, player.id) {
-            character.movement_speed = WALK_SPEED;
+            character.movement_speed = config.walk_speed;
             new_state = match new_state {
                 CharacterState::Running => CharacterState::Walking,
                 CharacterState::Idle | CharacterState::Walking => new_state,
             }
         } else {
-            character.movement_speed = RUN_SPEED;
+            character.movement_speed = config.run_speed;
         }
 
         if let Some(direction) = new_direction {

--- a/src/core/character.rs
+++ b/src/core/character.rs
@@ -2,10 +2,6 @@ use bevy::math::Vec2;
 use bevy::prelude::Timer;
 
 use super::collider::Collision;
-
-pub const WALK_SPEED: f32 = 175.0;
-pub const RUN_SPEED: f32 = 400.0;
-
 #[derive(Debug)]
 pub struct Character {
     pub direction: Direction,
@@ -67,7 +63,7 @@ impl Default for Character {
             state: CharacterState::Idle,
             previous_state: CharacterState::Idle,
             velocity: Vec2::ZERO,
-            movement_speed: WALK_SPEED,
+            movement_speed: 0.0,
             collision: Collision::default(),
         }
     }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub title: String,
 
     pub start_map: PathBuf,
+    pub map_scale: f32,
     pub start_dialogue: PathBuf,
 
     pub char_template: String,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -16,6 +16,9 @@ pub struct Config {
     pub char_template: String,
     pub char_height: f32,
     pub char_width: f32,
+    pub walk_speed: f32,
+    pub run_speed: f32,
+
 }
 
 pub fn load_asset_config(name: &str) -> Result<Config> {

--- a/src/items.rs
+++ b/src/items.rs
@@ -4,7 +4,7 @@ use bevy::{asset::FileAssetIo, prelude::*};
 use bevy::utils::HashSet;
 use bevy_tiled_prototype::{Map, Object};
 
-use crate::{core::{collider::{Collider, ColliderBehavior}, dialogue::{Dialogue, DialogueEvent}, game::{DialogueSpec, Game}, state::{AppState, TransientState}}, loading::LoadProgress, scene2d::load_next_map};
+use crate::{core::{config::Config,collider::{Collider, ColliderBehavior}, dialogue::{Dialogue, DialogueEvent}, game::{DialogueSpec, Game}, state::{AppState, TransientState}}, loading::LoadProgress, scene2d::load_next_map};
 
 #[derive(Debug, Default)]
 pub struct ItemsPlugin;
@@ -59,6 +59,7 @@ pub fn trigger_level_load_system(
     // mut entity_query: Query<(Entity, &Handle<Map>, &mut Visible, Option<&TileMapChunk>)>,
     // Todo: probably removed when level worflow improved
     transient_state: Res<TransientState>,
+    config: Res<Config>,
 ) {
     for interaction in interaction_reader.iter() {
         for behavior in interaction.behaviors.iter() {
@@ -79,7 +80,7 @@ pub fn trigger_level_load_system(
                         // eventually do preloading:
                         // game_state.next_map = Some(asset_server.load(level.as_str()));
                         game_state.current_map = to_load.add(asset_server.load(format!("maps/{}", level).as_str()));
-                        load_next_map(&mut commands, &mut game_state, &transient_state);
+                        load_next_map(&mut commands, &mut game_state, &transient_state, &config);
                         to_load.next_state = AppState::InGame;
                         to_load.next_dialogue = Some(path.clone());
                     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,8 +61,9 @@ fn main() -> Result<()> {
         // loading
         .add_system_set(SystemSet::on_update(AppState::Loading)
             .with_system(loading::wait_for_map_ready_system.system().before("main")) // this just removes Complicated tag
-            .with_system(loading::wait_for_asset_loading_system.system().label("main")))
-        .add_system_set(SystemSet::on_exit(AppState::Loading).with_system(scene2d::hide_non_map_objects_runonce.system()))
+            .with_system(loading::wait_for_asset_loading_system.system().label("main"))
+            .with_system(scene2d::create_tile_objects_system.system().after("main"))
+        ).add_system_set(SystemSet::on_exit(AppState::Loading).with_system(scene2d::hide_non_map_objects_runonce.system()))
 
         // menu
         .add_system_set(SystemSet::on_update(AppState::Menu)


### PR DESCRIPTION
Targeting branch of bery_tiled that supports collision shapes within objects. Also update tile -> object code to hackily register the objects for despawning along with the 0th map layer